### PR TITLE
fix: push to main workflow updates

### DIFF
--- a/.github/workflows/push_main.yaml
+++ b/.github/workflows/push_main.yaml
@@ -72,10 +72,40 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test, lint]
+    outputs:
+      version: ${{ steps.release.outputs.version }}
     steps:
       - uses: actions/checkout@master
       - uses: go-semantic-release/action@v1
+        id: release
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           allow-initial-development-versions: true
           force-bump-patch-version: true
+  build:
+    if: needs.release.outputs.version != ''
+    needs: [release]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: ["386", amd64, arm64]
+        goversion: ["1.17"]
+        exclude:  
+          - goarch: "386"
+            goos: darwin 
+          - goarch: "386"
+            goos: windows
+          - goarch: arm64
+            goos: windows 
+    steps:
+    - uses: actions/checkout@v2
+    - uses: wangyoucao577/go-release-action@v1.22
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        goversion: ${{ matrix.goversion }}
+        project_path: "./cmd/"
+        binary_name: "jsonpath"
+        ldflags: -X "main.Command=jsonpath" -X "main.Version=${{ needs.release.outputs.version }}" -X "main.OS=${{ matrix.goos }}" -X "main.Arch=${{ matrix.goarch }}"

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -1,7 +1,7 @@
-name: Release Build
+name: Manual Release Build
 on: 
   release:
-    types: [published]
+    types: [created]
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![codecov](https://codecov.io/gh/evilmonkeyinc/jsonpath/branch/main/graph/badge.svg?token=4PU85I7J2R)](https://codecov.io/gh/evilmonkeyinc/jsonpath)
-[![main](https://github.com/evilmonkeyinc/jsonpath/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/evilmonkeyinc/jsonpath/actions/workflows/test.yaml)
+[![Push Main](https://github.com/evilmonkeyinc/jsonpath/actions/workflows/push_main.yaml/badge.svg?branch=main)](https://github.com/evilmonkeyinc/jsonpath/actions/workflows/push_main.yaml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/evilmonkeyinc/jsonpath.svg)](https://pkg.go.dev/github.com/evilmonkeyinc/jsonpath)
 
 > This library is on the unstable version v0.X.X, which means there is a chance that any minor update may introduce a breaking change. Where I will endeavor to avoid this, care should be taken updating your dependency on this library until the first stable release v1.0.0 at which point any future breaking changes will result in a new major release.
@@ -219,5 +219,8 @@ For strings instead of returning an array of characters instead will return a su
 
 The [original specification for JSONPath](https://goessner.net/articles/JsonPath/) was proposed in 2007, and was a programing challenge I had not attempted before while being a practical tool.
 
+## Hows does this compare to...
+
 There are many [implementations](https://cburgmer.github.io/json-path-comparison/) in multiple languages so I will not claim that this library is better in any way but I believe that it is true to the original specification and was an enjoyable challenge.
 
+Sample queries and the expected response for this implementation compared to the community consensus are available [here](test/README.md)

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,6 @@
-# cburgmer tests
+# Consensus Tests
 
-This test package has tests detailed by https://cburgmer.github.io/json-path-comparison/ comparison matrix which details the community consensus on the expected response from multiple JSONPath queries
+This test package has tests detailed by https://cburgmer.github.io/json-path-comparison/ comparison matrix which details the community consensus on the expected response from multiple JSONPath queries by various implementations.
 	
 This implementation would be closer to the 'Scalar consensus' as it does not always return an array, but instead can return a single item when that is expected.
 	

--- a/test/helper_test.go
+++ b/test/helper_test.go
@@ -51,9 +51,9 @@ func batchTest(t *testing.T, tests []testData) {
 
 func Test_generateReadme(t *testing.T) {
 
-	header := `# cburgmer tests
+	header := `# Consensus Tests
 
-This test package has tests detailed by https://cburgmer.github.io/json-path-comparison/ comparison matrix which details the community consensus on the expected response from multiple JSONPath queries
+This test package has tests detailed by https://cburgmer.github.io/json-path-comparison/ comparison matrix which details the community consensus on the expected response from multiple JSONPath queries by various implementations.
 	
 This implementation would be closer to the 'Scalar consensus' as it does not always return an array, but instead can return a single item when that is expected.
 	`


### PR DESCRIPTION
update workflow to include generating builds automatically

rename release-build to manual release build as it will be triggered manually or by release via UI instead of workflows